### PR TITLE
Povolit HTTPS URL serveru.

### DIFF
--- a/pybakalib/client.py
+++ b/pybakalib/client.py
@@ -52,7 +52,7 @@ class BakaClient(object):
 
     @staticmethod
     def _fix_url(url,is_https):
-        if not url.startswith('http') and not is_https:
+        if not url.startswith('http') or not is_https:
             url = 'http://' + url
         url = url.replace('login.aspx', '')
         if not url.endswith('/'):

--- a/pybakalib/client.py
+++ b/pybakalib/client.py
@@ -44,15 +44,15 @@ class ResponseCache(object):
 
 class BakaClient(object):
     def __init__(self, url, cache=ResponseCache()):
-        self.url = BakaClient._fix_url(url)
+        self.url = BakaClient._fix_url(url,url.startswith("https"))
         self.token_perm = None
         self.token = None
         self.__available_modules = set()
         self.__module_cache = cache
 
     @staticmethod
-    def _fix_url(url):
-        if not url.startswith('http'):
+    def _fix_url(url,is_https):
+        if not url.startswith('http') and not is_https:
             url = 'http://' + url
         url = url.replace('login.aspx', '')
         if not url.endswith('/'):


### PR DESCRIPTION
Stáhl jsem si tuto knihovnu s domněním, že se mi ji podaří zprovoznit i se serverem naší školy. Po rychlém bádání jsem však zjistil, že daný server využívá šifrovaného připojení HTTPS, avšak pybakalib.client automaticky připojuje "http:\\" k URL, tudíž s čistou verzí knihovny se k danému serveru nepřipojím. Proto navrhuji možnost využít protokolu HTTPS (který je knihovnou `requests` podporován), jestliže by byl tento protokol přímo vyžádán v URL.